### PR TITLE
Trim whitespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "todo-trigger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "todo-trigger",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "roamjs-components": "^0.82.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "todo-trigger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Tie special actions to converting between TODOs and DONEs!",
   "main": "./build/main.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,13 @@ export default runExtension(async ({ extensionAPI }) => {
         action: { type: "switch" },
       },
       {
+        id: "trim",
+        name: "Trim Whitespace",
+        description:
+          "Trim the whitespace at the front and end when blocks become TODO or DONE",
+        action: { type: "switch" },
+      },
+      {
         id: "explode",
         name: "Explode",
         description: "Enable to play a fun animation when the TODO is finished",
@@ -169,6 +176,12 @@ export default runExtension(async ({ extensionAPI }) => {
         ? value
         : `${value}${formattedText}`;
     }
+    const trim = extensionAPI.settings.get("trim") as boolean;
+    if (trim) {
+      // replace whitespace after {{[[TODO]]}}
+      value = value.replace(/(\{\{\[\[TODO\]\]\}})\s+/g, "$1");
+      value = value.trim();
+    }
 
     if (value !== oldValue) {
       updateBlock({ uid: blockUid, text: value });
@@ -232,6 +245,12 @@ export default runExtension(async ({ extensionAPI }) => {
           value = value.replace(createTagRegex(before), "");
         }
       });
+    }
+    const trim = extensionAPI.settings.get("trim") as boolean;
+    if (trim) {
+      // replace whitespace after {{[[DONE]]}}
+      value = value.replace(/(\{\{\[\[DONE\]\]\}})\s+/g, "$1");
+      value = value.trim();
     }
     if (value !== oldValue) {
       updateBlock({ uid: blockUid, text: value });


### PR DESCRIPTION
from Mark Lavercombe on [slack](https://roamresearch.slack.com/archives/C016N2B66JU/p1693962355275089)

> In TODO Trigger, is there any chance a .trim() could be applied to the string when strikethrough is applied? I keep getting DONEs that look like this and the line between the checkbox and first letter and the extra line at the end bug me :grin:

![image](https://github.com/RoamJS/todo-trigger/assets/3792666/67bc31ad-c7f9-4c02-82c0-b507a3844d7c)


https://github.com/RoamJS/todo-trigger/assets/3792666/0f7754f1-df8d-4a20-8e59-ee3579e358a4

