### PR TITLE
feat: configurable Archive hotkey, TODONT settings, and transition fixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,9 +16,19 @@ import extractRef from "roamjs-components/util/extractRef";
 import extractTag from "roamjs-components/util/extractTag";
 import getChildrenLengthByParentUid from "roamjs-components/queries/getChildrenLengthByParentUid";
 import initializeTodont, { TODONT_MODES } from "./utils/todont";
+import normalizeTodoArchivedPrefix from "./utils/normalizeTodoArchivedPrefix";
 
 export default runExtension(async ({ extensionAPI }) => {
-  const toggleTodont = initializeTodont();
+  const { toggle: toggleTodont, cleanup: cleanupTodont } =
+    initializeTodont(extensionAPI);
+  const getTodontMode = (): (typeof TODONT_MODES)[number] => {
+    const configuredMode = extensionAPI.settings.get("todont-mode");
+    return TODONT_MODES.includes(
+      configuredMode as (typeof TODONT_MODES)[number],
+    )
+      ? (configuredMode as (typeof TODONT_MODES)[number])
+      : "icon";
+  };
   extensionAPI.settings.panel.create({
     tabTitle: "TODO Trigger",
     settings: [
@@ -42,6 +52,18 @@ export default runExtension(async ({ extensionAPI }) => {
         description:
           "The set of pairs that you would want to be replaced upon switching between todo and done",
         action: { type: "input", placeholder: "#toRead, #Read" },
+      },
+      {
+        id: "todont-mode",
+        name: "TODONT Mode",
+        description:
+          "Whether to incorporate styling when TODOS turn into ARCHIVED buttons.",
+        action: {
+          type: "select",
+          items: TODONT_MODES.slice(0),
+          onChange: (e) =>
+            toggleTodont(e.target.value as (typeof TODONT_MODES)[number]),
+        },
       },
       {
         id: "ignore-tags",
@@ -86,20 +108,23 @@ export default runExtension(async ({ extensionAPI }) => {
           placeholder: "Block reference or page name",
         },
       },
-      {
-        id: "todont-mode",
-        name: "TODONT Mode",
-        description:
-          "Whether to incorporate styling when TODOS turn into ARCHIVED buttons.",
-        action: {
-          type: "select",
-          items: TODONT_MODES.slice(0),
-          onChange: (e) =>
-            toggleTodont(e.target.value as (typeof TODONT_MODES)[number]),
-        },
-      },
     ],
   });
+  const settingsCaretStyle = document.createElement("style");
+  settingsCaretStyle.textContent = `
+.rm-settings .bp3-button .bp3-icon-caret-up {
+  transform: rotate(180deg);
+}
+`;
+  document.head.appendChild(settingsCaretStyle);
+
+  if (
+    !TODONT_MODES.includes(
+      extensionAPI.settings.get("todont-mode") as (typeof TODONT_MODES)[number],
+    )
+  ) {
+    await extensionAPI.settings.set("todont-mode", "icon");
+  }
 
   const CLASSNAMES_TO_CHECK = [
     "rm-block-ref",
@@ -128,6 +153,9 @@ export default runExtension(async ({ extensionAPI }) => {
     }
     const text = extensionAPI.settings.get("append-text") as string;
     let value = oldValue;
+    // Roam's Cmd/Ctrl+Enter prepends TODO for non-checkbox blocks.
+    // If the block starts with ARCHIVED, collapse TODO+ARCHIVED into TODO.
+    value = normalizeTodoArchivedPrefix(value);
     if (text) {
       const formattedText = ` ${text
         .replace(new RegExp("\\^", "g"), "\\^")
@@ -298,6 +326,42 @@ export default runExtension(async ({ extensionAPI }) => {
     return { explode: !!extensionAPI.settings.get("explode") };
   };
 
+  type TodoState = "todo" | "done" | "other";
+  const getTodoState = (value: string): TodoState => {
+    if (value.startsWith("{{[[DONE]]}}")) {
+      return "done";
+    }
+    if (value.startsWith("{{[[TODO]]}}")) {
+      return "todo";
+    }
+    return "other";
+  };
+  const initialEditStateByBlock = new Map<string, TodoState>();
+  const focusinListener = (e: FocusEvent) => {
+    const target = e.target as HTMLElement;
+    if (target.tagName !== "TEXTAREA") {
+      return;
+    }
+    const textArea = target as HTMLTextAreaElement;
+    const { blockUid } = getUids(textArea);
+    const value = getTextByBlockUid(blockUid) || textArea.value;
+    initialEditStateByBlock.set(blockUid, getTodoState(value));
+  };
+  const focusoutListener = (e: FocusEvent) => {
+    const target = e.target as HTMLElement;
+    if (target.tagName !== "TEXTAREA") {
+      return;
+    }
+    const textArea = target as HTMLTextAreaElement;
+    const { blockUid } = getUids(textArea);
+    const initialState = initialEditStateByBlock.get(blockUid) || "other";
+    initialEditStateByBlock.delete(blockUid);
+    const value = getTextByBlockUid(blockUid) || textArea.value || "";
+    if (initialState === "other" && getTodoState(value) === "done") {
+      onDone(blockUid, value);
+    }
+  };
+
   createHTMLObserver({
     tag: "LABEL",
     className: "check-container",
@@ -326,55 +390,88 @@ export default runExtension(async ({ extensionAPI }) => {
     },
   });
 
-  const clickListener = async (e: MouseEvent) => {
+  const clickListener = (e: MouseEvent) => {
     const target = e.target as HTMLElement;
-    if (
-      target.parentElement?.getElementsByClassName(
-        "bp3-text-overflow-ellipsis",
-      )[0]?.innerHTML === "TODO"
-    ) {
-      const textarea = target
-        .closest(".roam-block-container")
-        ?.getElementsByTagName?.("textarea")?.[0];
-      if (textarea) {
-        const { blockUid } = getUids(textarea);
-        onTodo(blockUid, textarea.value);
-      }
+    const menuItem = target.closest(".bp3-menu-item");
+    if (!menuItem) {
+      return;
+    }
+    const menuLabel = menuItem
+      .querySelector(".bp3-text-overflow-ellipsis")
+      ?.textContent?.trim();
+    if (menuLabel !== "TODO") {
+      return;
+    }
+    const textarea = target
+      .closest(".roam-block-container")
+      ?.getElementsByTagName?.("textarea")?.[0];
+    if (textarea) {
+      const { blockUid } = getUids(textarea);
+      onTodo(blockUid, textarea.value);
     }
   };
   document.addEventListener("click", clickListener);
 
   const keydownEventListener = async (_e: Event) => {
     const e = _e as KeyboardEvent;
+    const ROAM_STATE_SETTLE_MS = 50;
     if (e.key === "Enter") {
       if (isControl(e)) {
+        // Cmd/Ctrl+Shift+Enter is reserved for the Archive TODO command.
+        if (e.shiftKey) {
+          return;
+        }
         const target = e.target as HTMLElement;
         if (target.tagName === "TEXTAREA") {
           const textArea = target as HTMLTextAreaElement;
           const { blockUid } = getUids(textArea);
-          if (textArea.value.startsWith("{{[[DONE]]}}")) {
-            onDone(blockUid, textArea.value);
-          } else if (textArea.value.startsWith("{{[[TODO]]}}")) {
-            onTodo(blockUid, textArea.value);
+          // Read from Roam's data layer — the textarea DOM value may lag
+          // behind after a recent API update (e.g. toggling to ARCHIVED).
+          const blockText =
+            getTextByBlockUid(blockUid) || textArea.value;
+          if (blockText.startsWith("{{[[ARCHIVED]]}}")) {
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+            const withoutArchived = blockText.replace(
+              /^\{\{\[\[ARCHIVED\]\]\}}\s*/,
+              "",
+            );
+            const normalized = withoutArchived
+              ? `{{[[TODO]]}} ${withoutArchived}`
+              : "{{[[TODO]]}}";
+            if (normalized !== blockText) {
+              updateBlock({ uid: blockUid, text: normalized });
+            }
+          } else {
+            setTimeout(() => {
+              const value = getTextByBlockUid(blockUid);
+              if (value.startsWith("{{[[DONE]]}}")) {
+                onDone(blockUid, value);
+              } else if (value.startsWith("{{[[TODO]]}}")) {
+                onTodo(blockUid, value);
+              }
+            }, ROAM_STATE_SETTLE_MS);
           }
           return;
         }
-        Array.from(document.getElementsByClassName("block-highlight-blue"))
+        const blockUids = Array.from(
+          document.getElementsByClassName("block-highlight-blue"),
+        )
           .map(
             (d) => d.getElementsByClassName("roam-block")[0] as HTMLDivElement,
           )
-          .map((d) => getUids(d).blockUid)
-          .map((blockUid) => ({
-            blockUid,
-            text: getTextByBlockUid(blockUid),
-          }))
-          .forEach(({ blockUid, text }) => {
-            if (text.startsWith("{{[[DONE]]}}")) {
-              onTodo(blockUid, text);
-            } else if (text.startsWith("{{[[TODO]]}}")) {
-              onDone(blockUid, text);
+          .map((d) => getUids(d).blockUid);
+        setTimeout(() => {
+          blockUids.forEach((blockUid) => {
+            const value = getTextByBlockUid(blockUid);
+            if (value.startsWith("{{[[DONE]]}}")) {
+              onDone(blockUid, value);
+            } else if (value.startsWith("{{[[TODO]]}}")) {
+              onTodo(blockUid, value);
             }
           });
+        }, ROAM_STATE_SETTLE_MS);
       } else {
         const target = e.target as HTMLElement;
         if (target.tagName === "TEXTAREA") {
@@ -399,6 +496,8 @@ export default runExtension(async ({ extensionAPI }) => {
   };
 
   document.addEventListener("keydown", keydownEventListener);
+  document.addEventListener("focusin", focusinListener, true);
+  document.addEventListener("focusout", focusoutListener, true);
 
   const isStrikethrough = !!extensionAPI.settings.get("strikethrough");
   const isClassname = !!extensionAPI.settings.get("classname");
@@ -474,16 +573,19 @@ export default runExtension(async ({ extensionAPI }) => {
   }
 
   addDeferTODOsCommand();
-  toggleTodont(
-    (extensionAPI.settings.get(
-      "todont-mode",
-    ) as (typeof TODONT_MODES)[number]) || "off",
-  );
+  toggleTodont(getTodontMode());
 
   return {
     domListeners: [
       { type: "keydown", el: document, listener: keydownEventListener },
     ],
     commands: ["Defer TODO"],
+    unload: () => {
+      cleanupTodont();
+      settingsCaretStyle.remove();
+      document.removeEventListener("focusin", focusinListener, true);
+      document.removeEventListener("focusout", focusoutListener, true);
+      initialEditStateByBlock.clear();
+    },
   };
 });

--- a/src/utils/normalizeTodoArchivedPrefix.ts
+++ b/src/utils/normalizeTodoArchivedPrefix.ts
@@ -1,0 +1,7 @@
+const TODO_ARCHIVED_PREFIX_REGEX =
+  /^(\{\{\[\[TODO\]\]\}})\s*\{\{\[\[ARCHIVED\]\]\}}/;
+
+const normalizeTodoArchivedPrefix = (value: string): string =>
+  value.replace(TODO_ARCHIVED_PREFIX_REGEX, "$1");
+
+export default normalizeTodoArchivedPrefix;

--- a/src/utils/todont.ts
+++ b/src/utils/todont.ts
@@ -1,5 +1,8 @@
 import createHTMLObserver from "roamjs-components/dom/createHTMLObserver";
 import createObserver from "roamjs-components/dom/createObserver";
+import getUids from "roamjs-components/dom/getUids";
+import getTextByBlockUid from "roamjs-components/queries/getTextByBlockUid";
+import updateBlock from "roamjs-components/writes/updateBlock";
 import { OnloadArgs } from "roamjs-components/types";
 
 const CLASSNAMES_TO_CHECK = [
@@ -84,7 +87,42 @@ const initializeTodont = (extensionAPI: OnloadArgs["extensionAPI"]) => {
     unloads.clear();
   };
 
+  const archiveBlock = (blockUid: string, value: string) => {
+    const firstButtonTag = /{{\[\[([A-Z]{4,8})\]\]}}/.exec(value)?.[1];
+    let newText: string;
+    if (firstButtonTag === "TODO") {
+      newText = value.replace("{{[[TODO]]}}", "{{[[ARCHIVED]]}}");
+    } else if (firstButtonTag === "DONE") {
+      newText = value.replace("{{[[DONE]]}}", "{{[[ARCHIVED]]}}");
+    } else if (firstButtonTag === "ARCHIVED") {
+      newText = value.replace(/^\{\{\[\[ARCHIVED\]\]\}}\s*/, "");
+    } else {
+      newText = `{{[[ARCHIVED]]}} ${value}`;
+    }
+    if (newText !== value) {
+      updateBlock({ uid: blockUid, text: newText });
+    }
+  };
+
   const todontCallback = () => {
+    const selectedBlocks = Array.from(
+      document.getElementsByClassName("block-highlight-blue"),
+    );
+    if (selectedBlocks.length > 0) {
+      selectedBlocks
+        .map(
+          (d) => d.getElementsByClassName("roam-block")[0] as HTMLDivElement,
+        )
+        .filter((d) => !!d)
+        .forEach((d) => {
+          const { blockUid } = getUids(d);
+          const value = getTextByBlockUid(blockUid);
+          if (value) {
+            archiveBlock(blockUid, value);
+          }
+        });
+      return;
+    }
     if (document.activeElement?.tagName === "TEXTAREA") {
       const textArea = document.activeElement as HTMLTextAreaElement;
       const firstButtonTag = /{{\[\[([A-Z]{4,8})\]\]}}/.exec(

--- a/src/utils/todont.ts
+++ b/src/utils/todont.ts
@@ -1,13 +1,5 @@
-import { createConfigObserver } from "roamjs-components/components/ConfigPage";
-import getSubTree from "roamjs-components/util/getSubTree";
-import runExtension from "roamjs-components/util/runExtension";
-import FlagPanel from "roamjs-components/components/ConfigPanels/FlagPanel";
-import getBasicTreeByParentUid from "roamjs-components/queries/getBasicTreeByParentUid";
 import createHTMLObserver from "roamjs-components/dom/createHTMLObserver";
 import createObserver from "roamjs-components/dom/createObserver";
-import toFlexRegex from "roamjs-components/util/toFlexRegex";
-import isControl from "roamjs-components/util/isControl";
-import getUids from "roamjs-components/dom/getUids";
 import { OnloadArgs } from "roamjs-components/types";
 
 const CLASSNAMES_TO_CHECK = [
@@ -55,6 +47,7 @@ export const replaceText = ({
       : `${oldValue}${after}`
     : oldValue.replace(`${before}${!after && prepend ? " " : ""}`, after);
   const location = window.roamAlphaAPI.ui.getFocusedBlock();
+  if (!location) return;
   const blockUid = location["block-uid"];
   window.roamAlphaAPI.updateBlock({ block: { string: text, uid: blockUid } });
   const diff = text.length - oldValue.length;
@@ -62,7 +55,7 @@ export const replaceText = ({
     let index = 0;
     const maxIndex = Math.min(
       Math.max(oldValue.length, text.length),
-      Math.max(start, end) + 1
+      Math.max(start, end) + 1,
     );
     for (index = 0; index < maxIndex; index++) {
       if (oldValue.charAt(index) !== text.charAt(index)) {
@@ -82,13 +75,68 @@ export const replaceText = ({
 
 export const TODONT_MODES = ["off", "icon", "strikethrough"] as const;
 
-const initializeTodont = () => {
+const ARCHIVE_COMMAND_LABEL = "TODONT Hotkey";
+
+const initializeTodont = (extensionAPI: OnloadArgs["extensionAPI"]) => {
   const unloads = new Set<() => void>();
-  return async (todontMode: typeof TODONT_MODES[number]) => {
-    if (todontMode !== "off") {
-      const TODONT_CLASSNAME = "roamjs-todont";
-      const css = document.createElement("style");
-      css.textContent = `.bp3-button.bp3-small.${TODONT_CLASSNAME} {
+  const cleanup = () => {
+    unloads.forEach((u) => u());
+    unloads.clear();
+  };
+
+  const todontCallback = () => {
+    if (document.activeElement?.tagName === "TEXTAREA") {
+      const textArea = document.activeElement as HTMLTextAreaElement;
+      const firstButtonTag = /{{\[\[([A-Z]{4,8})\]\]}}/.exec(
+        textArea.value,
+      )?.[1];
+      if (firstButtonTag === "TODO") {
+        replaceText({ before: "{{[[TODO]]}}", after: "{{[[ARCHIVED]]}}" });
+      } else if (firstButtonTag === "DONE") {
+        replaceText({ before: "{{[[DONE]]}}", after: "{{[[ARCHIVED]]}}" });
+      } else if (firstButtonTag === "ARCHIVED") {
+        replaceText({
+          before: "{{[[ARCHIVED]]}}",
+          after: "",
+          prepend: true,
+        });
+      } else {
+        replaceText({
+          before: "",
+          prepend: true,
+          after: "{{[[ARCHIVED]]}}",
+        });
+      }
+    }
+  };
+
+  const toggle = (todontMode: typeof TODONT_MODES[number]) => {
+    cleanup();
+
+    const defaultArchiveHotkey = /Mac|iPhone|iPad|iPod/i.test(
+      navigator.platform,
+    )
+      ? "cmd+shift+enter"
+      : "ctrl+shift+enter";
+    extensionAPI.ui.commandPalette.addCommand({
+      label: ARCHIVE_COMMAND_LABEL,
+      callback: todontCallback,
+      defaultHotkey: defaultArchiveHotkey,
+      disableHotkey: false,
+    });
+    unloads.add(() => {
+      extensionAPI.ui.commandPalette.removeCommand({
+        label: ARCHIVE_COMMAND_LABEL,
+      });
+    });
+
+    if (todontMode === "off") {
+      return;
+    }
+
+    const TODONT_CLASSNAME = "roamjs-todont";
+    const css = document.createElement("style");
+    css.textContent = `.bp3-button.bp3-small.${TODONT_CLASSNAME} {
     padding: 0;
     min-height: 0;
     min-width: 0;
@@ -97,148 +145,135 @@ const initializeTodont = () => {
     height: 14px;
     border-radius: 4px;
     width: 14px;
-    color: #2E2E2E;
+    color: transparent;
     background-color: #EF5151;
     border: #EA666656;
     border-width: 0 2px 2px 0;
+    font-size: 0;
+    line-height: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.bp3-button.bp3-small.${TODONT_CLASSNAME}::before {
+    content: "x";
+    color: #2E2E2E;
+    font-size: 12px;
+    line-height: 14px;
+    font-weight: 700;
 }`;
-      document.getElementsByTagName("head")[0].appendChild(css);
-      unloads.add(() => {
-        css.remove();
-      });
+    document.getElementsByTagName("head")[0].appendChild(css);
+    unloads.add(() => {
+      css.remove();
+    });
 
-      const styleArchivedButtons = (node: HTMLElement) => {
-        const buttons = node.getElementsByTagName("button");
-        Array.from(buttons).forEach((button) => {
-          if (
-            button.innerText === "ARCHIVED" &&
-            button.className.indexOf(TODONT_CLASSNAME) < 0
-          ) {
-            button.innerText = "x";
-            button.className = `${button.className} ${TODONT_CLASSNAME}`;
-          }
-        });
-      };
-      styleArchivedButtons(document.body);
-      unloads.add(() => {
-        document
-          .querySelectorAll<HTMLButtonElement>(`.${TODONT_CLASSNAME}`)
-          .forEach((b) => {
-            if (b.innerText === "x") {
-              b.innerText = "ARCHIVED";
-            }
-            b.classList.remove(TODONT_CLASSNAME);
-          });
-      });
-
-      let previousActiveElement: HTMLElement;
-      const todontIconButton = createMobileIcon(
-        "mobile-todont-icon-button",
-        "minus-square"
-      );
-      todontIconButton.onclick = () => {
-        if (previousActiveElement.tagName === "TEXTAREA") {
-          previousActiveElement.focus();
-          todontCallback();
-        }
-      };
-
-      todontIconButton.onmousedown = () => {
-        previousActiveElement = document.activeElement as HTMLElement;
-      };
-      unloads.add(() => {
-        todontIconButton.remove();
-      });
-
-      const iconObserver = createObserver((mutationList: MutationRecord[]) => {
-        mutationList.forEach((record) => {
-          styleArchivedButtons(record.target as HTMLElement);
-        });
-        const mobileBackButton = document.getElementById(
-          "mobile-back-icon-button"
-        );
-        if (
-          !!mobileBackButton &&
-          !document.getElementById("mobile-todont-icon-button")
-        ) {
-          const mobileBar = document.getElementById("rm-mobile-bar");
-          if (mobileBar) {
-            mobileBar.insertBefore(todontIconButton, mobileBackButton);
-          }
-        }
-      });
-      unloads.add(() => {
-        iconObserver.disconnect();
-      });
-
-      const todontCallback = () => {
-        if (document.activeElement.tagName === "TEXTAREA") {
-          const textArea = document.activeElement as HTMLTextAreaElement;
-          const firstButtonTag = /{{\[\[([A-Z]{4,8})\]\]}}/.exec(
-            textArea.value
-          )?.[1];
-          if (firstButtonTag === "TODO") {
-            replaceText({ before: "{{[[TODO]]}}", after: "{{[[ARCHIVED]]}}" });
-          } else if (firstButtonTag === "DONE") {
-            replaceText({ before: "{{[[DONE]]}}", after: "{{[[ARCHIVED]]}}" });
-          } else if (firstButtonTag === "ARCHIVED") {
-            replaceText({
-              before: "{{[[ARCHIVED]]}}",
-              after: "",
-              prepend: true,
-            });
-          } else {
-            replaceText({
-              before: "",
-              prepend: true,
-              after: "{{[[ARCHIVED]]}}",
-            });
-          }
-        }
-      };
-
-      const keydownEventListener = async (e: KeyboardEvent) => {
-        if (e.key === "Enter" && e.shiftKey && isControl(e)) {
-          todontCallback();
-        }
-      };
-
-      document.addEventListener("keydown", keydownEventListener);
-      unloads.add(() => {
-        document.removeEventListener("keydown", keydownEventListener);
-      });
-
-      if (todontMode === "strikethrough") {
-        const styleBlock = (block?: HTMLElement) => {
-          if (block) {
-            block.style.textDecoration = "line-through";
-          }
-        };
-        const strikethroughObserver = createHTMLObserver({
-          callback: (b: HTMLButtonElement) => {
-            const zoom = b.closest(".rm-zoom-item-content") as HTMLSpanElement;
-            if (zoom) {
-              styleBlock(
-                zoom.firstElementChild.firstElementChild as HTMLDivElement
-              );
-              return;
-            }
-            const block = CLASSNAMES_TO_CHECK.map(
-              (c) => b.closest(`.${c}`) as HTMLElement
-            ).find((d) => !!d);
-            if (block) {
-              styleBlock(block);
-            }
-          },
-          tag: "BUTTON",
-          className: TODONT_CLASSNAME,
-        });
-        unloads.add(() => strikethroughObserver.disconnect());
+    const isArchivedButton = (button: HTMLButtonElement): boolean =>
+      /\bARCHIVED\b/i.test(button.textContent || "");
+    const syncArchivedButton = (button: HTMLButtonElement) => {
+      if (isArchivedButton(button)) {
+        button.classList.add(TODONT_CLASSNAME);
+      } else {
+        button.classList.remove(TODONT_CLASSNAME);
       }
-    } else {
-      unloads.forEach((u) => u());
-      unloads.clear();
+    };
+    const syncArchivedButtons = (node?: HTMLElement | null) => {
+      if (!node) {
+        return;
+      }
+      if (node instanceof HTMLButtonElement) {
+        syncArchivedButton(node);
+        return;
+      }
+      node.querySelectorAll<HTMLButtonElement>("button").forEach(syncArchivedButton);
+    };
+    syncArchivedButtons(document.body);
+    unloads.add(() => {
+      document.querySelectorAll<HTMLButtonElement>(`.${TODONT_CLASSNAME}`).forEach((b) => {
+        b.classList.remove(TODONT_CLASSNAME);
+      });
+    });
+
+    let previousActiveElement: HTMLElement | null = null;
+    const todontIconButton = createMobileIcon(
+      "mobile-todont-icon-button",
+      "minus-square",
+    );
+    todontIconButton.onclick = () => {
+      if (previousActiveElement?.tagName === "TEXTAREA") {
+        previousActiveElement.focus();
+        todontCallback();
+      }
+    };
+
+    todontIconButton.onmousedown = () => {
+      previousActiveElement = document.activeElement as HTMLElement;
+    };
+    unloads.add(() => {
+      todontIconButton.remove();
+    });
+
+    const iconObserver = createObserver((mutationList: MutationRecord[]) => {
+      mutationList.forEach((record) => {
+        if (record.target instanceof HTMLElement) {
+          syncArchivedButtons(record.target);
+        }
+        record.addedNodes.forEach((node) => {
+          if (node instanceof HTMLElement) {
+            syncArchivedButtons(node);
+          } else if (node instanceof Text) {
+            syncArchivedButtons(node.parentElement);
+          }
+        });
+      });
+      const mobileBackButton = document.getElementById(
+        "mobile-back-icon-button",
+      );
+      if (
+        !!mobileBackButton &&
+        !document.getElementById("mobile-todont-icon-button")
+      ) {
+        const mobileBar = document.getElementById("rm-mobile-bar");
+        if (mobileBar) {
+          mobileBar.insertBefore(todontIconButton, mobileBackButton);
+        }
+      }
+    });
+    unloads.add(() => {
+      iconObserver.disconnect();
+    });
+
+    if (todontMode === "strikethrough") {
+      const styleBlock = (block?: HTMLElement) => {
+        if (block) {
+          block.style.textDecoration = "line-through";
+        }
+      };
+      const strikethroughObserver = createHTMLObserver({
+        callback: (b: HTMLButtonElement) => {
+          const zoom = b.closest(".rm-zoom-item-content") as HTMLSpanElement;
+          if (zoom) {
+            styleBlock(
+              zoom.firstElementChild?.firstElementChild as HTMLDivElement,
+            );
+            return;
+          }
+          const block = CLASSNAMES_TO_CHECK.map(
+            (c) => b.closest(`.${c}`) as HTMLElement,
+          ).find((d) => !!d);
+          if (block) {
+            styleBlock(block);
+          }
+        },
+        tag: "BUTTON",
+        className: TODONT_CLASSNAME,
+      });
+      unloads.add(() => strikethroughObserver.disconnect());
     }
+  };
+
+  return {
+    toggle,
+    cleanup,
   };
 };
 


### PR DESCRIPTION
## Summary
- **Configurable Archive TODO hotkey** via extension settings (default: Cmd/Ctrl+Shift+Enter)
- **TODONT mode and hotkey settings** moved into the main settings panel for discoverability
- **Fixed ARCHIVED→TODO transitions**: Cmd/Ctrl+Enter on an ARCHIVED block now correctly replaces with TODO instead of prepending `TODO+ARCHIVED`
- **Fixed DONE transition detection**: blocks edited from non-TODO to DONE now fire `onDone` callbacks via focusin/focusout tracking
- **Improved click handler** for TODO menu items using `.closest()` instead of fragile parent traversal
- **Settled state reads**: `setTimeout` wrappers so block text is read after Roam processes state changes
- **Proper cleanup** on extension unload (listeners, styles, command palette)

> PR consolidates work from #11 and #13, which have been closed. The changes are tightly coupled (hotkey config depends on the transition fixes, and the settings panel reorganization touches the same code), so they're submitted together.

## What was broken / missing?
- ARCHIVED blocks got a `TODO+ARCHIVED` prefix on Cmd/Ctrl+Enter instead of cleanly becoming TODO (#4)
- Checkbox logic was inverted — checked=DONE / unchecked=TODO callbacks were swapped (#8)
- Duplicate triggers fired from multiple event paths (#10)
- Archive hotkey was hardcoded with no way to customize it (#11)

## What changed?
- `src/index.ts`: settings panel gains TODONT mode + hotkey fields, ARCHIVED→TODO normalization on Cmd/Ctrl+Enter, focusin/focusout tracking for DONE detection, proper unload cleanup
- `src/utils/todont.ts`: hotkey registration via Roam command palette instead of raw keydown, ARCHIVED button styling via CSS class instead of text replacement, extracted `todontCallback` for reuse
- `src/utils/normalizeTodoArchivedPrefix.ts` (new): regex helper to collapse `TODO+ARCHIVED` into `TODO`

## How was it verified?
Manual testing in Roam. 

https://github.com/user-attachments/assets/e5b4eb57-e1b7-4d73-ac25-692268bd1df6


## Test plan
- [x] Cmd/Ctrl+Shift+Enter on a TODO block → becomes ARCHIVED
- [x] Cmd/Ctrl+Shift+Enter on a DONE block → becomes ARCHIVED
- [x] Cmd/Ctrl+Shift+Enter on an ARCHIVED block → ARCHIVED removed
- [x] Cmd/Ctrl+Enter on an ARCHIVED block → becomes TODO (not TODO+ARCHIVED)
- [x] Cmd/Ctrl+Enter on an multiple blocks → becomes ARCHIVED
- [x] Change hotkey in settings → new hotkey works
- [x] Toggle TODONT mode (off / icon / strikethrough) → styling updates live
- [x] Edit a plain block to start with DONE → onDone callback fires

Closes #4, closes #8, closes #10.