### PR TITLE
Fix ARCHIVED → TODO transition on Cmd/Ctrl+Enter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -375,9 +375,9 @@ export default runExtension(async ({ extensionAPI }) => {
               updateBlock({ uid: blockUid, text: normalized });
             }
           } else if (blockText.startsWith("{{[[DONE]]}}")) {
-            onDone(blockUid, blockText);
-          } else if (blockText.startsWith("{{[[TODO]]}}")) {
             onTodo(blockUid, blockText);
+          } else if (blockText.startsWith("{{[[TODO]]}}")) {
+            onDone(blockUid, blockText);
           }
           return;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,8 +356,8 @@ export default runExtension(async ({ extensionAPI }) => {
         if (target.tagName === "TEXTAREA") {
           const textArea = target as HTMLTextAreaElement;
           const { blockUid } = getUids(textArea);
-          // Read from Roam's data layer — the textarea DOM value may lag
-          // behind after a recent API update (e.g. toggling to ARCHIVED).
+          // Check data layer for ARCHIVED state — the textarea DOM value
+          // may lag behind after a recent API update.
           const blockText =
             getTextByBlockUid(blockUid) || textArea.value;
           if (blockText.startsWith("{{[[ARCHIVED]]}}")) {
@@ -374,10 +374,10 @@ export default runExtension(async ({ extensionAPI }) => {
             if (normalized !== blockText) {
               updateBlock({ uid: blockUid, text: normalized });
             }
-          } else if (blockText.startsWith("{{[[DONE]]}}")) {
-            onTodo(blockUid, blockText);
-          } else if (blockText.startsWith("{{[[TODO]]}}")) {
-            onDone(blockUid, blockText);
+          } else if (textArea.value.startsWith("{{[[DONE]]}}")) {
+            onDone(blockUid, textArea.value);
+          } else if (textArea.value.startsWith("{{[[TODO]]}}")) {
+            onTodo(blockUid, textArea.value);
           }
           return;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import extractRef from "roamjs-components/util/extractRef";
 import extractTag from "roamjs-components/util/extractTag";
 import getChildrenLengthByParentUid from "roamjs-components/queries/getChildrenLengthByParentUid";
 import initializeTodont, { TODONT_MODES } from "./utils/todont";
+import normalizeTodoArchivedPrefix from "./utils/normalizeTodoArchivedPrefix";
 
 export default runExtension(async ({ extensionAPI }) => {
   const toggleTodont = initializeTodont();
@@ -128,6 +129,9 @@ export default runExtension(async ({ extensionAPI }) => {
     }
     const text = extensionAPI.settings.get("append-text") as string;
     let value = oldValue;
+    // Roam's Cmd/Ctrl+Enter prepends TODO for non-checkbox blocks.
+    // If the block starts with ARCHIVED, collapse TODO+ARCHIVED into TODO.
+    value = normalizeTodoArchivedPrefix(value);
     if (text) {
       const formattedText = ` ${text
         .replace(new RegExp("\\^", "g"), "\\^")
@@ -352,10 +356,28 @@ export default runExtension(async ({ extensionAPI }) => {
         if (target.tagName === "TEXTAREA") {
           const textArea = target as HTMLTextAreaElement;
           const { blockUid } = getUids(textArea);
-          if (textArea.value.startsWith("{{[[DONE]]}}")) {
-            onDone(blockUid, textArea.value);
-          } else if (textArea.value.startsWith("{{[[TODO]]}}")) {
-            onTodo(blockUid, textArea.value);
+          // Read from Roam's data layer — the textarea DOM value may lag
+          // behind after a recent API update (e.g. toggling to ARCHIVED).
+          const blockText =
+            getTextByBlockUid(blockUid) || textArea.value;
+          if (blockText.startsWith("{{[[ARCHIVED]]}}")) {
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation();
+            const withoutArchived = blockText.replace(
+              /^\{\{\[\[ARCHIVED\]\]\}}\s*/,
+              "",
+            );
+            const normalized = withoutArchived
+              ? `{{[[TODO]]}} ${withoutArchived}`
+              : "{{[[TODO]]}}";
+            if (normalized !== blockText) {
+              updateBlock({ uid: blockUid, text: normalized });
+            }
+          } else if (blockText.startsWith("{{[[DONE]]}}")) {
+            onDone(blockUid, blockText);
+          } else if (blockText.startsWith("{{[[TODO]]}}")) {
+            onTodo(blockUid, blockText);
           }
           return;
         }

--- a/src/utils/normalizeTodoArchivedPrefix.ts
+++ b/src/utils/normalizeTodoArchivedPrefix.ts
@@ -1,0 +1,7 @@
+const TODO_ARCHIVED_PREFIX_REGEX =
+  /^(\{\{\[\[TODO\]\]\}})\s*\{\{\[\[ARCHIVED\]\]\}}/;
+
+const normalizeTodoArchivedPrefix = (value: string): string =>
+  value.replace(TODO_ARCHIVED_PREFIX_REGEX, "$1");
+
+export default normalizeTodoArchivedPrefix;


### PR DESCRIPTION
## Summary
- When pressing Cmd/Ctrl+Enter on an ARCHIVED block, Roam prepends TODO resulting in `TODO+ARCHIVED`. This normalizes that into just `TODO`.
- Reads block text from Roam's data layer (`getTextByBlockUid`) instead of the textarea DOM value, which can lag behind after API updates.
- Adds a new `normalizeTodoArchivedPrefix` utility that collapses `{{[[TODO]]}} {{[[ARCHIVED]]}}` into `{{[[TODO]]}}`.

https://github.com/user-attachments/assets/181cefad-cbd7-4322-a2c2-94087fca65c9

## Test plan
- [x] Place cursor on an ARCHIVED block → press Cmd/Ctrl+Enter → block becomes TODO (not TODO+ARCHIVED)
- [x] Place cursor on a TODO block → press Cmd/Ctrl+Enter → block becomes DONE (unchanged behavior)
- [x] Place cursor on a DONE block → press Cmd/Ctrl+Enter → block becomes TODO (unchanged behavior)

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of ARCHIVED TODO items when using keyboard shortcuts to toggle status.
  * Fixed inconsistent behavior when using keyboard shortcuts to change TODO state.

* **New Features**
  * Enhanced keyboard shortcut processing to properly normalize and handle ARCHIVED items consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/roamjs/todo-trigger/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
